### PR TITLE
Update of module api doc link

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -166,7 +166,7 @@
                 <h3>Interested in developing your own modules?</h3>
                 <p>
                     MagicMirror² has an extensively documentated API. It allows you to built your own module backed by a powerful backend.<br>
-                    Check out the <a href="https://github.com/MichMich/MagicMirror/blob/master/modules/README.md" target="_blank">API documentation</a> for more information and start developing today.
+                    Check out the <a href="https://docs.magicmirror.builders/development/introduction.html" target="_blank">API documentation</a> for more information and start developing today.
                 </p>
 
                 <h3>Interested in similar projects?</h3>


### PR DESCRIPTION
I am not sure about this link but the old on is dead. 
So my educated guess is the magi mirror documentation about module development